### PR TITLE
initialize design system with CSS variables and reusable UI components

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -36,6 +36,17 @@
     box-shadow: var(--shadow-md);
 }
 
+/* ── Enhanced Dark Mode Buttons ── */
+[data-theme="dark"] .btn-primary {
+    background: linear-gradient(135deg, #3B82F6 0%, #8B5CF6 100%);
+    box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+}
+
+[data-theme="dark"] .btn-primary:hover {
+    background: linear-gradient(135deg, #2563EB 0%, #7C3AED 100%);
+    box-shadow: 0 6px 20px rgba(59, 130, 246, 0.4);
+}
+
 .btn-secondary {
     background: var(--bg-tertiary);
     color: var(--text-primary);
@@ -45,6 +56,19 @@
 .btn-secondary:hover {
     background: var(--bg-elevated);
     border-color: var(--border-primary);
+}
+
+/* ── Enhanced Dark Mode Secondary Buttons ── */
+[data-theme="dark"] .btn-secondary {
+    background: rgba(41, 45, 54, 0.8);
+    border-color: rgba(255, 255, 255, 0.06);
+    color: var(--text-secondary);
+}
+
+[data-theme="dark"] .btn-secondary:hover {
+    background: rgba(59, 130, 246, 0.1);
+    border-color: rgba(59, 130, 246, 0.3);
+    color: var(--brand-primary);
 }
 
 .btn-success {
@@ -135,6 +159,19 @@
     border-color: var(--border-primary);
     box-shadow: var(--shadow-lg);
     transform: translateY(-3px);
+}
+
+/* ── Enhanced Dark Mode Cards ── */
+[data-theme="dark"] .card {
+    background: linear-gradient(135deg, rgba(31, 34, 41, 0.9) 0%, rgba(26, 29, 35, 0.9) 100%);
+    border-color: rgba(255, 255, 255, 0.06);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme="dark"] .card:hover {
+    background: linear-gradient(135deg, rgba(41, 45, 54, 0.95) 0%, rgba(31, 34, 41, 0.95) 100%);
+    border-color: rgba(59, 130, 246, 0.3);
+    box-shadow: 0 8px 30px rgba(59, 130, 246, 0.2);
 }
 
 .card-flat {
@@ -339,6 +376,19 @@
     box-shadow: 0 0 0 3px rgba(0, 120, 212, 0.15);
 }
 
+/* ── Enhanced Dark Mode Input Fields ── */
+[data-theme="dark"] .input {
+    background: rgba(41, 45, 54, 0.6);
+    border-color: rgba(255, 255, 255, 0.06);
+    color: var(--text-primary);
+}
+
+[data-theme="dark"] .input:focus {
+    background: rgba(41, 45, 54, 0.8);
+    border-color: rgba(59, 130, 246, 0.5);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
 .input::placeholder {
     color: var(--text-muted);
 }
@@ -413,6 +463,17 @@
 
 .modal-overlay.active .modal {
     transform: scale(1) translateY(0);
+}
+
+/* ── Enhanced Dark Mode Modal ── */
+[data-theme="dark"] .modal {
+    background: linear-gradient(135deg, rgba(20, 23, 28, 0.95) 0%, rgba(26, 29, 35, 0.95) 100%);
+    border-color: rgba(255, 255, 255, 0.08);
+    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
+}
+
+[data-theme="dark"] .modal-overlay {
+    background: rgba(0, 0, 0, 0.8);
 }
 
 .modal-header {

--- a/css/global.css
+++ b/css/global.css
@@ -32,6 +32,15 @@ body {
     transition: background-color var(--transition-base), color var(--transition-base);
 }
 
+/* ── Enhanced Dark Mode Background ── */
+[data-theme="dark"] {
+    background: var(--bg-primary);
+    background-image: 
+        radial-gradient(circle at 20% 50%, rgba(59, 130, 246, 0.05) 0%, transparent 50%),
+        radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.05) 0%, transparent 50%),
+        radial-gradient(circle at 40% 20%, rgba(6, 182, 212, 0.05) 0%, transparent 50%);
+}
+
 /* ── Scrollbar ── */
 ::-webkit-scrollbar {
     width: 8px;

--- a/css/navbar.css
+++ b/css/navbar.css
@@ -16,6 +16,15 @@
     transition: background var(--transition-base), height var(--transition-base);
 }
 
+/* ── Enhanced Dark Mode Navbar ── */
+[data-theme="dark"] .navbar {
+    background: rgba(10, 11, 15, 0.8);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
 .navbar .container {
     display: flex;
     align-items: center;
@@ -80,8 +89,20 @@
 }
 
 .nav-link.active {
-    color: var(--brand-primary-light);
-    background: rgba(0, 120, 212, 0.1);
+    color: var(--brand-primary);
+    background: var(--brand-gradient-soft);
+    box-shadow: 0 2px 8px rgba(59, 130, 246, 0.2);
+}
+
+/* ── Enhanced Dark Mode Navigation Links ── */
+[data-theme="dark"] .nav-link:hover {
+    background: rgba(59, 130, 246, 0.1);
+    color: var(--brand-primary);
+}
+
+[data-theme="dark"] .nav-link.active {
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.2) 0%, rgba(139, 92, 246, 0.2) 100%);
+    color: var(--text-primary);
 }
 
 .nav-actions {
@@ -405,4 +426,4 @@
     .menu-btn-text {
         display: none;
     }
-}
+}

--- a/css/variables.css
+++ b/css/variables.css
@@ -3,26 +3,30 @@
    ============================================ */
 
 :root {
-  /* ── Brand Colors ── */
-  --brand-primary: #0078D4;
-  --brand-primary-light: #3291FF;
-  --brand-primary-dark: #005A9E;
-  --brand-secondary: #00BCF2;
-  --brand-accent: #00BCF2;
-  --brand-accent-light: #50E0E0;
-  --brand-gradient: linear-gradient(135deg, #0078D4 0%, #00BCF2 100%);
-  --brand-gradient-hover: linear-gradient(135deg, #005A9E 0%, #0091D1 100%);
-  --brand-gradient-soft: linear-gradient(135deg, rgba(0, 120, 212, 0.1) 0%, rgba(0, 188, 242, 0.1) 100%);
+  /* ── Enhanced Brand Colors ── */
+  --brand-primary: #3B82F6;
+  --brand-primary-light: #60A5FA;
+  --brand-primary-dark: #2563EB;
+  --brand-secondary: #8B5CF6;
+  --brand-accent: #06B6D4;
+  --brand-accent-light: #22D3EE;
+  --brand-gradient: linear-gradient(135deg, #3B82F6 0%, #8B5CF6 100%);
+  --brand-gradient-hover: linear-gradient(135deg, #2563EB 0%, #7C3AED 100%);
+  --brand-gradient-soft: linear-gradient(135deg, rgba(59, 130, 246, 0.1) 0%, rgba(139, 92, 246, 0.1) 100%);
 
-  /* ── Semantic Colors ── */
-  --color-success: #00B894;
-  --color-success-light: rgba(0, 184, 148, 0.15);
-  --color-warning: #FDCB6E;
-  --color-warning-light: rgba(253, 203, 110, 0.15);
-  --color-error: #E17055;
-  --color-error-light: rgba(225, 112, 85, 0.15);
-  --color-info: #74B9FF;
-  --color-info-light: rgba(116, 185, 255, 0.15);
+  /* ── Enhanced Semantic Colors ── */
+  --color-success: #10B981;
+  --color-success-light: rgba(16, 185, 129, 0.15);
+  --color-success-dark: #059669;
+  --color-warning: #F59E0B;
+  --color-warning-light: rgba(245, 158, 11, 0.15);
+  --color-warning-dark: #D97706;
+  --color-error: #EF4444;
+  --color-error-light: rgba(239, 68, 68, 0.15);
+  --color-error-dark: #DC2626;
+  --color-info: #06B6D4;
+  --color-info-light: rgba(6, 182, 212, 0.15);
+  --color-info-dark: #0891B2;
 
   /* ── Typography ── */
   --font-primary: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
@@ -99,31 +103,63 @@
 }
 
 /* ============================================
-   Dark Theme (Default)
+   Dark Theme (Default) - Enhanced
    ============================================ */
 :root,
 [data-theme="dark"] {
-  --bg-primary: #0F0F1A;
-  --bg-secondary: #1A1A2E;
-  --bg-tertiary: #222240;
-  --bg-elevated: #2A2A4A;
-  --bg-card: rgba(26, 26, 46, 0.8);
-  --bg-card-hover: rgba(42, 42, 74, 0.9);
-  --bg-glass: rgba(15, 15, 26, 0.7);
-  --bg-input: rgba(34, 34, 64, 0.6);
+  /* ── Enhanced Background Palette ── */
+  --bg-primary: #0A0B0F;
+  --bg-secondary: #14151A;
+  --bg-tertiary: #1A1D23;
+  --bg-elevated: #1F2229;
+  --bg-card: rgba(31, 34, 41, 0.8);
+  --bg-card-hover: rgba(41, 45, 54, 0.9);
+  --bg-glass: rgba(10, 11, 15, 0.7);
+  --bg-input: rgba(41, 45, 54, 0.6);
+  --bg-surface: #1E2128;
+  --bg-overlay: rgba(0, 0, 0, 0.8);
 
-  --border-primary: rgba(0, 120, 212, 0.2);
-  --border-subtle: rgba(255, 255, 255, 0.08);
-  --border-hover: rgba(0, 120, 212, 0.4);
+  /* ── Enhanced Border System ── */
+  --border-primary: rgba(59, 130, 246, 0.3);
+  --border-subtle: rgba(255, 255, 255, 0.06);
+  --border-hover: rgba(59, 130, 246, 0.5);
+  --border-focus: rgba(59, 130, 246, 0.6);
+  --border-accent: rgba(139, 92, 246, 0.4);
 
-  --text-primary: #F0F0F8;
-  --text-secondary: #A0A0C0;
-  --text-muted: #6B6B8D;
-  --text-inverse: #0F0F1A;
+  /* ── Enhanced Typography ── */
+  --text-primary: #F8FAFC;
+  --text-secondary: #CBD5E1;
+  --text-muted: #94A3B8;
+  --text-inverse: #0A0B0F;
+  --text-accent: #A5B4FC;
+  --text-success: #86EFAC;
+  --text-warning: #FDE047;
+  --text-error: #FCA5A5;
 
-  --scrollbar-track: #1A1A2E;
-  --scrollbar-thumb: #3A3A5A;
-  --scrollbar-thumb-hover: #4A4A6A;
+  /* ── Enhanced Shadows for Dark Mode ── */
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 3px 6px rgba(0, 0, 0, 0.4), 0 2px 4px rgba(0, 0, 0, 0.3);
+  --shadow-lg: 0 10px 20px rgba(0, 0, 0, 0.4), 0 3px 6px rgba(0, 0, 0, 0.3);
+  --shadow-xl: 0 15px 35px rgba(0, 0, 0, 0.5), 0 5px 15px rgba(0, 0, 0, 0.4);
+  --shadow-glow: 0 0 30px rgba(59, 130, 246, 0.3);
+  --shadow-glow-accent: 0 0 30px rgba(139, 92, 246, 0.3);
+
+  /* ── Enhanced Scrollbar ── */
+  --scrollbar-track: #1A1D23;
+  --scrollbar-thumb: #475569;
+  --scrollbar-thumb-hover: #64748B;
+
+  /* ── Dark Mode Specific Colors ── */
+  --accent-primary: #3B82F6;
+  --accent-secondary: #8B5CF6;
+  --accent-success: #10B981;
+  --accent-warning: #F59E0B;
+  --accent-error: #EF4444;
+
+  /* ── Surface Gradients ── */
+  --surface-gradient: linear-gradient(135deg, #1A1D23 0%, #14151A 100%);
+  --card-gradient: linear-gradient(135deg, rgba(31, 34, 41, 0.9) 0%, rgba(26, 29, 35, 0.9) 100%);
+  --accent-gradient: linear-gradient(135deg, #3B82F6 0%, #8B5CF6 100%);
 }
 
 /* ============================================


### PR DESCRIPTION
## Overview
This PR focuses on initializing and refining our Design System through a comprehensive overhaul of the Dark Mode UI. The goal was to move away from basic dark colors to a sophisticated, modern, and high-contrast theme that provides a superior user experience compared to the initial implementation.

### Key Changes
**1. Core Design System (CSS Variables)**
- **Richer Palette**: Updated variables.css with deeper backgrounds (transitioned from #0F0F1A to #0A0B0F).

- **Improved Typography**: Enhanced readability using #F8FAFC for primary text and #CBD5E1 for secondary text.

- **Semantic Colors**: Refined Brand, Success, Warning, and Error colors to ensure harmony across both light and dark themes.

 **2. Visual Enhancements**
**Depth & Hierarchy**: Added subtle radial gradients and realistic shadows to create a sense of layering.

**Glassmorphism**: Improved backdrop filters and border highlights for a modern "glass" effect on containers.

**Refined Borders**: Transitioned to subtle rgba(255, 255, 255, 0.06) borders for a cleaner look.

 **3. Component Updates**
- **Navbar:** Enhanced glass effect with better blur and navigation link active states.

- **Buttons:** Modernized with blue-to-purple gradients (#3B82F6 to #8B5CF6) and improved hover feedback.

- **Cards**: Added gradient backgrounds and enhanced border highlights to make them "pop."

- **Forms & Modals**: Redesigned input focus states with glow effects and adjusted modal overlays for better focus.

### Files Modified

1. **variables.css:** Core color system and semantic tokens.

1. **global.css:** Global dark mode styling and transitions.

1. **navbar.css:** Navigation-specific UI improvements.

1. **components.css**: Overhaul of Buttons, Cards, Modals, and Inputs.


## Screenshots:

<img width="960" height="422" alt="E1" src="https://github.com/user-attachments/assets/7d49fb27-4d13-442c-86dc-054bddad48a5" />

<img width="949" height="413" alt="E2" src="https://github.com/user-attachments/assets/34af1360-21cf-4495-b0e5-87b1d84d3511" />

