### PR TITLE
fix: derive sidebar progress from loaded lessons

### DIFF
--- a/js/components/__tests__/sidebar.test.js
+++ b/js/components/__tests__/sidebar.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SidebarComponent } from '../sidebar.js';
+
+vi.mock('../../services/storage.js', () => ({
+  storage: {
+    getCourseProgress: vi.fn(() => ({
+      completedLessons: ['lesson-1', 'lesson-2'],
+      completedModules: [],
+    })),
+  },
+}));
+
+describe('SidebarComponent', () => {
+  it('uses loaded lesson count for progress', () => {
+    const container = {
+      innerHTML: '',
+      querySelectorAll: vi.fn(() => []),
+    };
+    const course = {
+      id: 'course-1',
+      title: 'Course 1',
+      totalLessons: 1,
+    };
+    const lessons = [
+      { id: 'lesson-1', title: 'Lesson 1', type: 'theory' },
+      { id: 'lesson-2', title: 'Lesson 2', type: 'practice' },
+    ];
+
+    new SidebarComponent(container, course, lessons, 'lesson-1');
+
+    expect(container.innerHTML).toContain('<span>2/2 lessons</span>');
+    expect(container.innerHTML).toContain('<span>100%</span>');
+    expect(container.innerHTML).toContain('style="width:100%"');
+    expect(course.totalLessons).toBe(1);
+  });
+});

--- a/js/components/sidebar.js
+++ b/js/components/sidebar.js
@@ -33,7 +33,7 @@ export class SidebarComponent {
     render() {
         const courseProgress = storage.getCourseProgress(this.course.id);
         const completedCount = courseProgress.completedLessons.length;
-        const totalLessons = this.course.totalLessons;
+        const totalLessons = this.lessons.length;
         const percent = Math.round((completedCount / totalLessons) * 100);
 
         // build module + lesson list if modules provided


### PR DESCRIPTION
## Summary

Derive course sidebar progress from the loaded lesson list so dynamically added lessons cannot produce progress above 100%, with a focused regression.

## Change

- `js/components/__tests__/sidebar.test.js`
- `js/components/sidebar.js`

### Checks
- `npm test -- js/components/__tests__/sidebar.test.js` — passed in a network-isolated container.

Fixes #56

---
AI assistance was used; I reviewed and own this change.

<!-- northset-receipt:M-104:start -->
### Verification

[Northset proof-of-pass receipt M-104](https://northset-oss.github.io/verification-pilot/receipts/M-104/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-104:end -->
